### PR TITLE
Replace image classes with col-md-4

### DIFF
--- a/src/www/campustreks/index.php
+++ b/src/www/campustreks/index.php
@@ -26,13 +26,13 @@
         <section class="portfolio-block photography">
             <div class="container">
                 <div class="row no-gutters">
-                    <div class="col-md-6 col-lg-4 item zoom-on-hover">
+                    <div class="col-md-4">
 						<img class="img-fluid" src="img/Forum_Back.jpg">
 					</div>
-                    <div class="col-md-6 col-lg-4 item zoom-on-hover">
+                    <div class="col-md-4">
 						<img class="img-fluid" src="img/Students_on_Campus.jpg">
 					</div>
-                    <div class="col-md-6 col-lg-4 item zoom-on-hover">
+                    <div class="col-md-4">
 						<img class="img-fluid" src="img/Forum_Overhead.jpg">
 					</div>
                 </div>


### PR DESCRIPTION
Bootstrap adds indexes to 12, so three 4s = 12, closes #95